### PR TITLE
feat: Ajout du reste à payer pour les factures d'acompte

### DIFF
--- a/src/app/components/PrintDocument.tsx
+++ b/src/app/components/PrintDocument.tsx
@@ -21,6 +21,7 @@ export interface PrintDocumentProps {
     total: number;
   }[];
   total: number;
+  notes?: string;
 }
 
 interface ParametresEntreprise {
@@ -45,7 +46,8 @@ export default function PrintDocument({
   clientEmail,
   clientPhone,
   lines,
-  total
+  total,
+  notes
 }: PrintDocumentProps) {
   const [parametres, setParametres] = useState<ParametresEntreprise | null>(null);
   const [loading, setLoading] = useState(true);
@@ -357,9 +359,41 @@ export default function PrintDocument({
             <tfoot>
               <tr>
                 <td colSpan={3}></td>
-                <td className="total-row">TOTAL</td>
+                <td className="total-row">{notes && notes.includes('FACTURE D\'ACOMPTE') ? 'MONTANT DE CET ACOMPTE' : 'TOTAL'}</td>
                 <td className="total-value">{formatMontant(total)} €</td>
               </tr>
+              {/* Afficher le reste à payer pour les factures d'acompte */}
+              {notes && notes.includes('FACTURE D\'ACOMPTE') && notes.includes('- Montant restant à payer:') && (
+                (() => {
+                  const montantRestantMatch = notes.match(/- Montant restant à payer: ([\d,]+\.?\d*) €/);
+                  const montantRestant = montantRestantMatch ? parseFloat(montantRestantMatch[1].replace(',', '')) : null;
+                  
+                  return montantRestant ? (
+                    <tr style={{ backgroundColor: '#dbeafe' }}>
+                      <td colSpan={3}></td>
+                      <td style={{ 
+                        fontWeight: 'bold', 
+                        backgroundColor: '#3b82f6',
+                        color: '#ffffff',
+                        fontSize: '16px',
+                        padding: '10px'
+                      }}>
+                        RESTE À PAYER
+                      </td>
+                      <td style={{ 
+                        fontWeight: 'bold',
+                        backgroundColor: '#3b82f6',
+                        color: '#ffffff',
+                        fontSize: '16px',
+                        padding: '10px',
+                        textAlign: 'right'
+                      }}>
+                        {formatMontant(montantRestant)} €
+                      </td>
+                    </tr>
+                  ) : null;
+                })()
+              )}
             </tfoot>
           </table>
         )}

--- a/src/app/devis/[id]/page.tsx
+++ b/src/app/devis/[id]/page.tsx
@@ -643,6 +643,7 @@ export default function DetailDevis({ params }: { params: { id: string } }) {
           clientPhone={devis.client.telephone}
           lines={devis.lignes}
           total={total}
+          notes={devis.notes}
         />
       </div>
     </>

--- a/src/app/factures/[id]/page.tsx
+++ b/src/app/factures/[id]/page.tsx
@@ -552,6 +552,7 @@ export default function DetailFacture({ params }: { params: { id: string } }) {
           clientPhone={facture.client.telephone}
           lines={facture.lignes}
           total={total}
+          notes={facture.notes}
         />
       </div>
 

--- a/src/app/paiements/[id]/page.tsx
+++ b/src/app/paiements/[id]/page.tsx
@@ -312,6 +312,7 @@ export default function DetailPaiement({ params }: { params: { id: string } }) {
             total: paiement.montant
           }]}
           total={paiement.montant}
+          notes={paiement.notes}
         />
       </div>
     </>

--- a/src/app/print/page.tsx
+++ b/src/app/print/page.tsx
@@ -23,6 +23,7 @@ interface DocumentData {
     total: number;
   }>;
   total: number;
+  notes?: string;
 }
 
 // Composant de chargement pour le Suspense
@@ -262,6 +263,7 @@ function PrintContent() {
           clientPhone={documentData.clientPhone}
           lines={documentData.lines}
           total={documentData.total}
+          notes={documentData.notes}
         />
       </div>
     </>


### PR DESCRIPTION
- Affichage 'MONTANT DE CET ACOMPTE' au lieu de 'TOTAL'
- Ligne 'RESTE À PAYER' en bleu mise en évidence
- Extraction automatique du montant depuis les notes
- Affichage uniquement pour factures d'acompte, normal pour autres documents
- Interface propre et minimaliste sans sections superflues